### PR TITLE
When current time gets stuck in a buffer gap, seek to next available …

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,7 +6,7 @@
 
 import {MediaSource, URL} from 'videojs-contrib-media-sources';
 import PlaylistLoader from './playlist-loader';
-import SegmentLoader from './segment-loader';
+import {default as SegmentLoader, CODE_BUFFER_GAP} from './segment-loader';
 import Playlist from './playlist';
 import m3u8 from './m3u8';
 import {Decrypter, AsyncStream, decrypt} from './decrypter';
@@ -251,7 +251,13 @@ HlsHandler.prototype.src = function(src) {
     this.playlists.media(this.selectPlaylist());
   }.bind(this));
   this.segments.on('error', function() {
-    this.blacklistCurrentPlaylist_(this.segments.error());
+    let error = this.segments.error();
+
+    if (error.code === CODE_BUFFER_GAP) {
+      this.tech_.setCurrentTime(error.nextBufferStart);
+    } else {
+      this.blacklistCurrentPlaylist_(this.segments.error());
+    }
   }.bind(this));
 
   // do nothing if the tech has been disposed already

--- a/src/ranges.js
+++ b/src/ranges.js
@@ -27,6 +27,24 @@ const filterRanges = function(timeRanges, predicate) {
 };
 
 /**
+ * Attempts to find a TimeRange between provided TimeRanges that contains the specified
+ * time.
+ * @param timeRanges {TimeRanges} the TimeRanges object to query
+ * @param time {number} the time to filter on
+ * @return a new TimeRange object
+ */
+const findGapWithTime = function(timeRanges, time) {
+  if (timeRanges && timeRanges.length > 1) {
+    for (let i = 1; i < timeRanges.length; i++) {
+      if (time > timeRanges.end(i - 1) && time < timeRanges.start(i)) {
+        return videojs.createTimeRange(timeRanges.end(i - 1), timeRanges.start(i));
+      }
+    }
+  }
+  return videojs.createTimeRange();
+};
+
+/**
  * Attempts to find the buffered TimeRange that contains the specified
  * time.
  * @param buffered {TimeRanges} the TimeRanges object to query
@@ -115,6 +133,7 @@ const findSoleUncommonTimeRangesEnd = function(original, update) {
 
 export default {
   findRange_: findRange,
+  findGapWithTime_: findGapWithTime,
   findNextRange_: findNextRange,
   findSoleUncommonTimeRangesEnd_: findSoleUncommonTimeRangesEnd,
   TIME_FUDGE_FACTOR


### PR DESCRIPTION
…buffer

When appending segments out of order, a small gap between buffered values may appear. For instance, if you have buffered range of 30-40, current time is 29, and you request the fragment that should give you 20-30, it is possible that the end buffered range is 20-30 and 32-40. In order to get around this, segment loader must throw an error and allow a listener to resolve the issue by seeking to an appropriate time.

Note that we consider a gap as erring when the gap is smaller than segment.duration / 2. This number is mostly magic, though seemed an OK rough estimate.

Note also that passing nextBufferStart may be leaking more information than should be passed in the error. But it may be OK for the simplicity of it.
